### PR TITLE
Re-add the `buyer` role as default role for any account

### DIFF
--- a/keycloak-realm-template.json
+++ b/keycloak-realm-template.json
@@ -80,7 +80,8 @@
         "composites": {
           "realm": [
             "offline_access",
-            "uma_authorization"
+            "uma_authorization",
+            "buyer"
           ],
           "client": {
             "account": [


### PR DESCRIPTION
Fixes https://frontend.gropius.duckdns.org/components/9de999cf-58cd-4b47-aa0e-860cd2b6869c/issues/47cd973e-a0fa-4419-9307-cb61d6e7f7f4